### PR TITLE
Fix some compiler warnings

### DIFF
--- a/src/bin/idchoppers.rs
+++ b/src/bin/idchoppers.rs
@@ -1,11 +1,11 @@
 use std::io::{self, Read, Write};
 
 extern crate idchoppers;
-use idchoppers::errors::Result;
+use idchoppers::errors::{Error, Result};
 extern crate svg;
 use svg::Document;
 use svg::node::Node;
-use svg::node::element::{Circle, Group, Line, Path, Rectangle, Style};
+use svg::node::element::{Group, Line, Path, Rectangle, Style};
 use svg::node::element::path::Data;
 extern crate termcolor;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
@@ -14,18 +14,23 @@ fn main() {
     match run() {
         Ok(()) => {}
         Err(err) => {
-            let mut stderr = StandardStream::stderr(ColorChoice::Auto);
-            stderr.set_color(ColorSpec::new().set_fg(Some(Color::Red)).set_bold(true));
-            write!(&mut stderr, "error: ");
-            stderr.set_color(&ColorSpec::new());
-            writeln!(&mut stderr, "{}", err);
+            drop(write_err(err));
         }
     }
 }
 
+fn write_err(err: Error) -> Result<()> {
+    let mut stderr = StandardStream::stderr(ColorChoice::Auto);
+    stderr.set_color(ColorSpec::new().set_fg(Some(Color::Red)).set_bold(true))?;
+    write!(&mut stderr, "error: ")?;
+    stderr.set_color(&ColorSpec::new())?;
+    writeln!(&mut stderr, "{}", err)?;
+    Ok(())
+}
+
 fn run() -> Result<()> {
     let mut buf = Vec::new();
-    io::stdin().read_to_end(&mut buf);
+    io::stdin().read_to_end(&mut buf)?;
 
     let wad = try!(idchoppers::parse_wad(buf.as_slice()));
     println!("found {:?}, {:?}, {:?}", wad.header.identification, wad.header.numlumps, wad.header.infotableofs);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,9 @@
-use nom;
+use std::io;
 
 error_chain! {
+    foreign_links {
+        Io(io::Error);
+    }
     errors {
         ParseError {
             description("nonspecific parse error")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ fn nom_to_result<I, O>(whence: &'static str, result: IResult<I, O>) -> Result<O>
         IResult::Done(_, value) => {
             return Ok(value);
         }
-        IResult::Incomplete(needed) => {
+        IResult::Incomplete(_) => {
             bail!(ErrorKind::TruncatedData(whence));
         }
         IResult::Error(err) => {
@@ -123,6 +123,7 @@ trait WAD {}
 
 /// High-level interface to a WAD archive.  Does its best to prevent you from producing an invalid
 /// WAD.  This is probably what you want.
+#[allow(dead_code)]
 pub struct WADArchive<'a> {
     // TODO it would be nice if we could take ownership of the slice somehow, but i don't know how
     // to do that really.  i also don't know how to tell rust that the entry slices are owned by
@@ -255,7 +256,7 @@ fn fixed_length_ascii(input: &[u8], len: usize) -> IResult<&[u8], &str> {
                 Ok(string) => {
                     return IResult::Done(leftovers, string.trim_right_matches('\0'));
                 }
-                Err(error) => {
+                Err(_) => {
                     // TODO preserve the utf8 error...  somehow.
                     return IResult::Error(nom::Err::Code(nom::ErrorKind::Custom(0)));
                 }
@@ -338,6 +339,7 @@ const MAP_LUMP_ORDER: [(&'static str, bool); 11] = [
     ("BEHAVIOR", false),
 ];
 
+#[allow(dead_code)]
 pub struct WADMapIterator<'a> {
     archive: &'a BareWAD<'a>,
     entry_iter: std::iter::Enumerate<std::slice::Iter<'a, BareWADDirectoryEntry<'a>>>,


### PR DESCRIPTION
Mostly simple stuff, but I did tweak the error printing routine to get rid of a bunch of "unused result" warnings from `set_color` and the other I/O stuff.